### PR TITLE
Added preliminary support to mark previous / next

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
       "multi-cursor-plus:select-to-first-character-of-line",
       "multi-cursor-plus:select-to-end-of-line",
       "multi-cursor-plus:select-to-top",
-      "multi-cursor-plus:select-to-bottom"
+      "multi-cursor-plus:select-to-bottom",
+      "multi-cursor-plus:mark-previous-like-this",
+      "multi-cursor-plus:mark-next-like-this"
     ]
   },
   "repository": "https://github.com/kankaristo/atom-multi-cursor-plus",
@@ -34,5 +36,7 @@
   "engines": {
     "atom": ">=0.174.0 <2.0.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "underscore-plus": "^1.6.6"
+  }
 }


### PR DESCRIPTION
There is one thing I badly miss form emacs `multiple-cursors.el` package, namely support for the operations *mark previous like this* and *mark next like this*, bound to `ctrl-<` and `ctrl->` respectively.

I used these actions as a poor man's refactoring tools, i.e. to rename variables. I essentially select the variable name, mark all further occurences and rename the variable throughout a file / scope.

I added a simple snippet to add these features to your package. Please tell me what you think.